### PR TITLE
[F] 修复当页面切换后返回，动画加速问题

### DIFF
--- a/static/js/rollSlide.js
+++ b/static/js/rollSlide.js
@@ -44,7 +44,7 @@
                 switch (ori){
                     case 'left':
                         $ul.append(cloneSliceItem);
-                        $ul.animate({
+                        $ul.stop(true, true).animate({
                             'left': -range + 'px'
                         },v,function(){
                             $(this).css({'left': 0});
@@ -55,7 +55,7 @@
                     case 'right':
                         $ul.prepend(cloneSliceItem);
                         $ul.css('left', -range + 'px');
-                        $ul.animate({
+                        $ul.stop(true, true).animate({
                             'left': 0
                         },v,function(){
                             $(sliceItem).remove();
@@ -64,7 +64,7 @@
                         break;
                     case 'top':
                         $ul.append(cloneSliceItem);
-                        $ul.animate({
+                        $ul.stop(true, true).animate({
                             'top': -range + 'px'
                         },v,function(){
                             $(this).css({'top': 0});
@@ -75,7 +75,7 @@
                     case 'bottom':
                         $ul.prepend(cloneSliceItem);
                         $ul.css('top', -range + 'px');
-                        $ul.animate({
+                        $ul.stop(true, true).animate({
                             'top': 0
                         },v, function(){
                             $(sliceItem).remove();


### PR DESCRIPTION
切换到其他页面一定时间后，返回本页面时，动画会被加速，这个过程中还可能导致`$ul.append(cloneSliceItem);`和`$(sliceItem).remove();`执行不一致，使得列表可能出现节点重复问题。